### PR TITLE
Allow settings to be controlled in admin panel

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,0 +1,5 @@
+en:
+  site_settings:
+    opencollective_enabled: "Enable opencollective plugin"
+    opencollective_collective_name: "Name of opencollective"
+    opencollective_access_token: "Access token for opencollective"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,10 @@
 plugins:
-  opencollective_collective_name: 'testcollective'
-#  opencollective_collective_name: ''
-  opencollective_access_token: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzY29wZSI6ImxvZ2luIiwiaWQiOjM5MzksImVtYWlsIjoiYXBpK3Rlc3R1c2VyQG9wZW5jb2xsZWN0aXZlLmNvbSIsImlhdCI6MTUwNDYxMDg5MCwiZXhwIjoxNTA3MjAyODkwLCJpc3MiOiJodHRwczovL2FwaS5vcGVuY29sbGVjdGl2ZS5jb20iLCJzdWIiOjM5Mzl9.Bm4VaPJhcq2TBI8uZnWIfbH7-c3Iz6MroleDU5PhdwQ'
-#  opencollective_access_token: ''
+  opencollective_enabled:
+    default: true
+    client: true
+  opencollective_collective_name:
+    default: ''
+    client: true
+  opencollective_access_token:
+    default: ''
+    client: false

--- a/plugin.rb
+++ b/plugin.rb
@@ -4,6 +4,7 @@
 # authors: Sudaraka Jayathilaka
 # url: https://github.com/sudaraka94/opencollective-plugin.git
 
+enabled_site_setting :opencollective_enabled
 
 require 'net/http'
 require 'uri'


### PR DESCRIPTION
I'm not super familiar with OpenCollective, but I'm guessing the access token is meant to be kept private.  Either way, I'd rather not commit to a repository so I thought I'd quickly hack in support for admin settings.

This is not fully tested yet, since I do not have access to an OpenCollective access token quite yet, but I did validate that Discourse continues to function as expected with the plugin loaded and that admin settings were present.