### PR TITLE
Refactor plugin to use single job

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -12,27 +12,22 @@ require 'json'
 module ::OpencollectivePlugin
   BADGE_NAME ||= 'OpenCollective Donator'.freeze
 
-  def self.get_data!
+  def self.badges_grant!
     token=SiteSetting.opencollective_access_token
     collective=SiteSetting.opencollective_collective_name
 
     if token=="" or collective==""
       puts "Fetching users from opencollective failed!"
       puts "Please configure settings.yml for the opencollective plugin"
-      ::PluginStore.set('discourse-opencollective-plugin','user_data', nil)
       return
     end
+
     conn = Faraday.new(url: 'https://opencollective.com',
                        headers: { 'Authorization' => "Bearer #{token}" })
 
     response = conn.get "/api/groups/#{collective}/users"
     data = JSON.parse response.body
-    # save the acquired json into plugin store
-    ::PluginStore.set('discourse-opencollective-plugin','user_data', data)
-  end
 
-  def self.badges_grant!
-    retrieve=::PluginStore.get('discourse-opencollective-plugin','user_data')
     if retrieve==nil
       puts "Granting badges for OpenCollective users failed!"
       return
@@ -57,16 +52,8 @@ end
 
 after_initialize do
   module ::OpencollectivePlugin
-    #this
-    class GetDataJob < ::Jobs::Scheduled
-      every 50.seconds
-
-      def execute(args)
-        OpencollectivePlugin.get_data!
-      end
-      end
     class GrantBadgeJob < ::Jobs::Scheduled
-      every 50.seconds
+      every 1.day
 
       def execute(args)
         OpencollectivePlugin.badges_grant!


### PR DESCRIPTION
In #3, I suggest that the `50.seconds` job schedule is far too frequent to be run in a production environment.  @sudaraka94 noted it was for testing and that he would reduce to `1.day`, which seems reasonable. However, this creates an issue because of the data caching.   If both jobs are set to `1.day`, badge granting may be behind by as much as 1 full day.  This wasn't noticeable before because at 50 second intervals, you're only behind a maximum of 50 seconds.

Since the jobs are interdependent, there is no need to cache the data for this plugin.  

This is mostly for proof of concept purposes as I do not have a OpenCollective token for testing, yet.  The main point is that the jobs should be reduced to 1 job for granting badges.