### PR TITLE
Minor fix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ hooks:
         cd: $home/plugins
         cmd:
           - mkdir -p plugins
-          - git clone https://github.com/sudaraka94/preventing-malicious-linking-plugin
+          - git clone https://github.com/sudaraka94/discourse-opencollective-integration
 ```
 
 and rebuild docker via


### PR DESCRIPTION
Updated `git clone` command to be https://github.com/sudaraka94/discourse-opencollective-integration

Thanks for the plugin! :smile: